### PR TITLE
doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This library provides a client that partially implements NTP v3 (RFC 1305). It a
 This repository contains two main library products:
 
 * `NTPClient`: Provides the high-level `NTPClient`. This is intended for consumption by other projects.
+  * [NTPClient documentation](https://swiftpackageindex.com/apple/swift-ntp/documentation/ntpclient)
 * `NTP`: (`package` level) Contains the core NTP protocol logic, packet parsing/serialization, and data structures. It is currently not publicly accessible.
 
 ## 💻 Examples

--- a/Snippets/simpleclient.swift
+++ b/Snippets/simpleclient.swift
@@ -3,7 +3,6 @@ import NTPClient
 // snippet.hide
 if #available(macOS 13.0, *) {
     // snippet.show
-
     let ntp = NTPClient(
         config: NTPClient.Config(
             version: .v4


### PR DESCRIPTION
- **add link to documentation hosted on Swift Package Index**
- **remove extra line in snippets final output - comments are treated as a blank line, and made an extra gap that wasn't intended**
