### PR TITLE
Fixed: potential arithmetic overflow in NTPPacket.getOffset()

### DIFF
--- a/Sources/NTP/NTPPacket.swift
+++ b/Sources/NTP/NTPPacket.swift
@@ -128,12 +128,30 @@ extension NTPPacket {
         return mutableLIVM
     }
 
-    package func getOffset(clientReceiveTime: UInt64) -> TimeInterval {
-        let a = Int64(bitPattern: self.receiveTime) - Int64(bitPattern: self.originTime)
-        let b = Int64(bitPattern: self.transmitTime) - Int64(bitPattern: clientReceiveTime)
-        let offset = a + (b - a) / 2
+    package func getOffset(clientReceiveTime: UInt64) throws -> TimeInterval {
+        let (a, aOverflowed) = Int64(bitPattern: self.receiveTime)
+            .subtractingReportingOverflow(Int64(bitPattern: self.originTime))
+        if aOverflowed {
+            throw _NTPError(.arithmeticOverflow)
+        }
+
+        let (b, bOverflowed) = Int64(bitPattern: self.transmitTime)
+            .subtractingReportingOverflow(Int64(bitPattern: clientReceiveTime))
+        if bOverflowed {
+            throw _NTPError(.arithmeticOverflow)
+        }
+
+        let (diff, diffOverflowed) = b.subtractingReportingOverflow(a)
+        if diffOverflowed {
+            throw _NTPError(.arithmeticOverflow)
+        }
+
+        let (offset, offsetOverflowed) = a.addingReportingOverflow(diff / 2)
+        if offsetOverflowed {
+            throw _NTPError(.arithmeticOverflow)
+        }
         if offset < 0 {
-            return -1 * NTPTime(-1 * offset).toInterval()
+            return -1 * NTPTime(offset.magnitude).toInterval()
         }
         return NTPTime(offset).toInterval()
     }

--- a/Sources/NTP/_NTPError.swift
+++ b/Sources/NTP/_NTPError.swift
@@ -12,17 +12,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Errors thrown during NTP operations.
-public struct NTPError: Error, Equatable, Hashable, CustomStringConvertible {
-    public var description: String {
+/// Errors thrown during low-level NTP packet operations.
+package struct _NTPError: Error, Sendable, Equatable, Hashable, CustomStringConvertible, CustomDebugStringConvertible {
+    package var debugDescription: String {
+        String(describing: self.base)
+    }
+
+    package var description: String {
         String(describing: self.base)
     }
 
     @usableFromInline
     enum Base: Equatable, Hashable, Sendable {
-        case responseNotReceived
-        case notEnoughBytes
-        case versionNotSupported
         case arithmeticOverflow
     }
 
@@ -32,27 +33,9 @@ public struct NTPError: Error, Equatable, Hashable, CustomStringConvertible {
     @inlinable
     init(_ base: Base) { self.base = base }
 
-    /// The client didn't receive a response from the NTP server.
-    @inlinable
-    public static var responseNotReceived: Self {
-        Self(.responseNotReceived)
-    }
-
-    /// Received data packet is too small to be a valid NTP response.
-    @inlinable
-    public static var notEnoughBytes: Self {
-        Self(.notEnoughBytes)
-    }
-
-    /// NTP version number in the server's response isn't supported by the client.
-    @inlinable
-    public static var versionNotSupported: Self {
-        Self(.versionNotSupported)
-    }
-
     /// Arithmetic overflow occurred during offset calculation
     @inlinable
-    public static var arithmeticOverflow: Self {
+    package static var arithmeticOverflow: Self {
         Self(.arithmeticOverflow)
     }
 }

--- a/Sources/NTPClient/Documentation.docc/NTPError.md
+++ b/Sources/NTPClient/Documentation.docc/NTPError.md
@@ -7,6 +7,7 @@
 - ``notEnoughBytes``
 - ``responseNotReceived``
 - ``versionNotSupported``
+- ``arithmeticOverflow``
 
 ### Inspecting an error
 

--- a/Sources/NTPClient/NTPResponse.swift
+++ b/Sources/NTPClient/NTPResponse.swift
@@ -97,8 +97,16 @@ extension NTPResponse {
             throw NTPError.versionNotSupported
         }
 
+        // Catch _NTPError and convert to NTPError
+        let offset: TimeInterval
+        do {
+            offset = try p.getOffset(clientReceiveTime: clientReceiveTime)
+        } catch let e as _NTPError where e == .arithmeticOverflow {
+            throw NTPError.arithmeticOverflow
+        }
+
         self.init(
-            offset: .seconds(p.getOffset(clientReceiveTime: clientReceiveTime)),
+            offset: .seconds(offset),
             roundTripDelay: .seconds(p.getRoundTripDelay(clientReceiveTime: clientReceiveTime)),
             serverTime: NTPTime(p.transmitTime).toDate(),
             version: version,

--- a/Tests/NTPTests/NTPPacketTests.swift
+++ b/Tests/NTPTests/NTPPacketTests.swift
@@ -90,6 +90,14 @@ struct OffsetTestData {
             clientReceiveTime: 16_957_530_838_418_870_272,  // origin + 05 seconds
             expected: 18
         ),
+        // offset = Int64.min + (0 / 2) = Int64.min → -2147483648.0 seconds
+        OffsetTestData(
+            originTime: 0,
+            serverReceiveTime: UInt64(bitPattern: Int64.min),
+            transmitTime: UInt64(bitPattern: Int64.min),
+            clientReceiveTime: 0,
+            expected: -2147483648.0
+        ),
         OffsetTestData(
             originTime: 16_957_536_211_640_536_064,
             serverReceiveTime: 16_957_536_215_935_503_360,  // origin + 1 seconds
@@ -99,7 +107,7 @@ struct OffsetTestData {
         ),
     ]
 )
-func testOffset(d: OffsetTestData) {
+func testOffset(d: OffsetTestData) throws {
     let p = NTPPacket(
         li: .noAdjustment,
         version: 3,
@@ -116,6 +124,73 @@ func testOffset(d: OffsetTestData) {
         transmitTime: d.transmitTime
     )
     #expect(
-        p.getOffset(clientReceiveTime: d.clientReceiveTime) == d.expected
+        try p.getOffset(clientReceiveTime: d.clientReceiveTime) == d.expected
     )
+}
+
+struct OffsetOverflowTestData {
+    let originTime: UInt64
+    let receiveTime: UInt64
+    let transmitTime: UInt64
+    let clientReceiveTime: UInt64
+}
+
+@Test(
+    "Ensure offset overflow is handled",
+    arguments: [
+        // case: overflow in calculating a
+        // a = recv_t - orig_t = 0 - Int64.min = overflow
+        OffsetOverflowTestData(
+            originTime: UInt64(bitPattern: Int64.min),
+            receiveTime: 0,
+            transmitTime: 0,
+            clientReceiveTime: 0
+        ),
+        // case: overflow in calculating b
+        // b = txmt_t - crecv_t = 0 - Int64.min = overflow
+        OffsetOverflowTestData(
+            originTime: 0,
+            receiveTime: 0,
+            transmitTime: 0,
+            clientReceiveTime: UInt64(bitPattern: Int64.min)
+        ),
+        // case: b - a = Int64.max + 1
+        // a = recv_t - orig_t = 0 - 1 = -1
+        // b = txmt_t - cRecv_t = Int64.max - 0 = Int64.max
+        OffsetOverflowTestData(
+            originTime: 1,
+            receiveTime: 0,
+            transmitTime: UInt64(bitPattern: Int64.max),
+            clientReceiveTime: 0
+        ),
+        // case: b - a = Int64.min - 1
+        // a = recv_t - orig_t = 1 - 0 = 1
+        // b = txmt_t - cRecv_t = Int64.min - 0 = Int64.min
+        OffsetOverflowTestData(
+            originTime: 0,
+            receiveTime: 1,
+            transmitTime: UInt64(bitPattern: Int64.min),
+            clientReceiveTime: 0
+        ),
+    ]
+)
+func testOffsetOverflow(d: OffsetOverflowTestData) {
+    let p = NTPPacket(
+        li: .noAdjustment,
+        version: 3,
+        mode: .server,
+        stratum: 2,
+        poll: 6,
+        precision: -20,
+        rootDelay: 0,
+        rootDispersion: 0,
+        referenceID: 0,
+        referenceTime: 0,
+        originTime: d.originTime,
+        receiveTime: d.receiveTime,
+        transmitTime: d.transmitTime
+    )
+    #expect(throws: _NTPError.arithmeticOverflow) {
+        try p.getOffset(clientReceiveTime: d.clientReceiveTime)
+    }
 }


### PR DESCRIPTION
Motivation:

Malformed NTP packets with large timestamp values can cause arithmetic overflow in the offset calculation, resulting in process crashes (EXC_BREAKPOINT).

Fixes #10

Modifications:

- added overflow checking in NTPPacket.getOffset()
- introduced package-level `_NTPError.arithmeticOverflow` for internal error handling
- added `NTPError.arithmeticOverflow` for surfacing it publicly.

Result:

Arithmetic overflow in offset calculations now throws instead of crashing, allowing applications to handle the errors instead of crashing.